### PR TITLE
Actually say that application/yaml is YAML

### DIFF
--- a/draft-ietf-httpapi-yaml-mediatypes.md
+++ b/draft-ietf-httpapi-yaml-mediatypes.md
@@ -108,7 +108,8 @@ the above media types according to {{!MEDIATYPE=RFC6838}}
 
 ## Media Type application/yaml {#application-yaml}
 
-The media type for YAML text is `application/yaml`.
+The media type for YAML text is `application/yaml`;
+the following information serves as the registration form for this media type.
 
 Type name:
 : application

--- a/draft-ietf-httpapi-yaml-mediatypes.md
+++ b/draft-ietf-httpapi-yaml-mediatypes.md
@@ -108,7 +108,7 @@ the above media types according to {{!MEDIATYPE=RFC6838}}
 
 ## Media Type application/yaml {#application-yaml}
 
-The following information serves as the registration form for the `application/yaml` media type.
+The media type for YAML text is `application/yaml`.
 
 Type name:
 : application


### PR DESCRIPTION
This might be a bit nitpicky, but I think the draft should explicitly say that `application/yaml` contains YAML.