### PR TITLE
Define fragment identifiers for application/yaml

### DIFF
--- a/draft-ietf-httpapi-yaml-mediatypes.md
+++ b/draft-ietf-httpapi-yaml-mediatypes.md
@@ -102,7 +102,7 @@ and "user agent"
 in this document are to be interpreted as in {{!SEMANTICS=I-D.ietf-httpbis-semantics}}.
 
 The terms "fragment" and "fragment identifier"
-in this document are to be interpreted as in {{!URI==RFC3986}}.
+in this document are to be interpreted as in {{!URI=RFC3986}}.
 
 The terms "node", "anchor" and "named anchor"
 in this document are to be intepreded as in [YAML].
@@ -114,7 +114,7 @@ named anchors (see Section 3.2.2.2 of [YAML])
 as fragment identifier to designate a node.
 
 A YAML named anchor can be represented in a URI fragment identifier
-by encoding it into octects using UTF-8 {{!UTF-8==RFC3629}},
+by encoding it into octects using UTF-8 {{!UTF-8=RFC3629}},
 while percent-encoding those characters not allowed by the fragment rule
 in {{Section 3.5 of URI}}. 
 
@@ -137,13 +137,13 @@ the URL `file.yaml#bar` references the anchor `bar` pointing to the node
 with value `[ some, sequence, items ]`.
 
 ~~~ example
-%YAML 1.2
----
-one: &foo scalar
-two: &bar
-  - some
-  - sequence
-  - items
+ %YAML 1.2
+ ---
+ one: &foo scalar
+ two: &bar
+   - some
+   - sequence
+   - items
 ~~~
 
 

--- a/draft-ietf-httpapi-yaml-mediatypes.md
+++ b/draft-ietf-httpapi-yaml-mediatypes.md
@@ -143,6 +143,8 @@ Fragment identifier considerations:
   but without a leading `*` indicator.
   For YAML 1.2,
   this means that it designates a node which has a correspondingly named anchor.
+  If multiple nodes would match a fragment identifier,
+  the first such match is selected.
 
 Additional information:
 

--- a/draft-ietf-httpapi-yaml-mediatypes.md
+++ b/draft-ietf-httpapi-yaml-mediatypes.md
@@ -101,6 +101,52 @@ The terms  "content", "content negotiation", "resource",
 and "user agent"
 in this document are to be interpreted as in {{!SEMANTICS=I-D.ietf-httpbis-semantics}}.
 
+The terms "fragment" and "fragment identifier"
+in this document are to be interpreted as in {{!URI==RFC3986}}.
+
+The terms "node", "anchor" and "named anchor"
+in this document are to be intepreded as in [YAML].
+
+## Fragment identification {#application-yaml-fragment}
+
+This section describes how to use
+named anchors (see Section 3.2.2.2 of [YAML])
+as fragment identifier to designate a node.
+
+A YAML named anchor can be represented in a URI fragment identifier
+by encoding it into octects using UTF-8 {{!UTF-8==RFC3629}},
+while percent-encoding those characters not allowed by the fragment rule
+in {{Section 3.5 of URI}}. 
+
+If multiple nodes would match a fragment identifier,
+the first such match is selected.
+
+Users concerned with interoperability of fragment identifiers:
+
+- SHOULD limit named anchors to a set of characters
+  that do not require encoding 
+  to be expressed as URI fragment identifiers:
+  this is always possible since named anchors are a serialization
+  detail;
+- SHOULD NOT use a named anchor that matches multiple nodes.
+
+In the example resource below, the URL `file.yaml#foo`
+references the anchor `foo` pointing to the node with value `scalar`;
+whereas
+the URL `file.yaml#bar` references the anchor `bar` pointing to the node
+with value `[ some, sequence, items ]`.
+
+~~~ example
+%YAML 1.2
+---
+one: &foo scalar
+two: &bar
+  - some
+  - sequence
+  - items
+~~~
+
+
 # Media Type registrations
 
 This section describes the information required to register
@@ -138,12 +184,7 @@ Applications that use this media type:
 : HTTP
 
 Fragment identifier considerations:
-: The fragment identifier is parsed as if it were a YAML alias node,
-  but without a leading `*` indicator.
-  For example, in YAML 1.2,
-  this means that it designates a node which has a correspondingly named anchor.
-  If multiple nodes would match a fragment identifier,
-  the first such match is selected.
+: see {{application-yaml-fragment}}
 
 Additional information:
 

--- a/draft-ietf-httpapi-yaml-mediatypes.md
+++ b/draft-ietf-httpapi-yaml-mediatypes.md
@@ -111,7 +111,7 @@ in this document are to be intepreded as in [YAML].
 
 This section describes how to use
 named anchors (see Section 3.2.2.2 of [YAML])
-as fragment identifier to designate a node.
+as fragment identifiers to designate nodes.
 
 A YAML named anchor can be represented in a URI fragment identifier
 by encoding it into octects using UTF-8 {{!UTF-8=RFC3629}},

--- a/draft-ietf-httpapi-yaml-mediatypes.md
+++ b/draft-ietf-httpapi-yaml-mediatypes.md
@@ -138,10 +138,9 @@ Applications that use this media type:
 : HTTP
 
 Fragment identifier considerations:
-: For documents labeled as `application/yaml`,
-  the fragment identifier is parsed as if it were a YAML alias node,
+: The fragment identifier is parsed as if it were a YAML alias node,
   but without a leading `*` indicator.
-  For YAML 1.2,
+  For example, in YAML 1.2,
   this means that it designates a node which has a correspondingly named anchor.
   If multiple nodes would match a fragment identifier,
   the first such match is selected.

--- a/draft-ietf-httpapi-yaml-mediatypes.md
+++ b/draft-ietf-httpapi-yaml-mediatypes.md
@@ -138,7 +138,11 @@ Applications that use this media type:
 : HTTP
 
 Fragment identifier considerations:
-: None
+: For documents labeled as `application/yaml`,
+  the fragment identifier is parsed as if it were a YAML alias node,
+  but without a leading `*` indicator.
+  For YAML 1.2,
+  this means that it designates a node which has a correspondingly named anchor.
 
 Additional information:
 


### PR DESCRIPTION
Closes #21

This defines `application/yaml` fragment identifiers to be parsed as YAML aliases, which currently means that they must point to an explicitly defined anchor in the document, a feature natively supported by YAML.

The definition intentionally allows for changes in later editions of the YAML spec to be automatically supported, e.g. as we're working towards supporting something like JSON pointers as well.

The language in the `+yaml` fragment identifier section seems a bit complex, and I'm not sure if it should be updated as well. Formats `xxx/yyy+yaml` should be allowed to define their own rules for fragment identifiers. Is this currently the case?