### PR TITLE
Link to latest YAML spec (1.2.2), mention all authors

### DIFF
--- a/draft-ietf-httpapi-yaml-mediatypes.md
+++ b/draft-ietf-httpapi-yaml-mediatypes.md
@@ -39,7 +39,11 @@ normative:
     - ins: Oren Ben-Kiki
     - ins: Clark Evans
     - ins: Ingy dot Net
-    target: https://yaml.org/spec/1.2/spec.html
+    - ins: Tina Müller
+    - ins: Pantelis Antoniou
+    - ins: Eemeli Aro
+    - ins: Thomas Smith
+    target: https://yaml.org/spec/1.2.2/
   oas:
     title: OpenAPI Specification 3.0.0
     date: 2017-07-26


### PR DESCRIPTION
Given that the text refers to specific sections of the YAML spec by number, and that the upstream isn't guaranteed to keep the exact same numbering for all YAML 1.2 patch releases, it would be good to explicitly link to the spec version that's used here, YAML 1.2.2.

The authors list was also incomplete for the 1.2.2 version: https://yaml.org/spec/1.2.2/ext/team/