### PR TITLE
+yaml MUST use application/yaml fragids.

### DIFF
--- a/draft-ietf-httpapi-yaml-mediatypes.md
+++ b/draft-ietf-httpapi-yaml-mediatypes.md
@@ -276,14 +276,7 @@ See {{MEDIATYPE}} for definitions of each of the registration form headings.
   : see {{application-yaml}}
 
   Fragment identifier considerations:
-  : Differently from `application/yaml`,
-    there is no fragment identification syntax defined
-    for +yaml.
-
-    A specific `xxx/yyy+yaml` media type
-    needs to define the syntax and semantics for fragment identifiers
-    because the ones in {{application-yaml}}
-    do not apply unless explicitly expressed.
+  : See {{application-yaml-fragment}}
 
   Interoperability considerations:
   : See {{application-yaml}}
@@ -613,6 +606,7 @@ Q: Why not just use JSON Pointer as the primary fragment identifier?
 ## Since draft-ietf-httpapi-yaml-mediatypes-02
 {: numbered="false"}
 
+* same fragment identifier for application/yaml and +yaml #54.
 * clarification on fragment identifiers #50.
 
 


### PR DESCRIPTION
## This PR

follows the long thread we had on #50 and #51.

1. +yaml SSS references application/yaml fragids.

## Note

Point 1.  means that:

-  according to RFC 6838 any xxx+yaml such as openapi+yaml, schema+yaml and ld+yaml MUST support application/yaml fragments including alias nodes resolution, and that client implementations, viewers and browsers might legitimately expect that behavior; 
-  xxx+yaml media types cannot override any of the above behavior;
- if one day the YAML community decides to define a fragid for plain names, it will legitimately prevail on all other plain name use in xxx+yaml.

