### PR TITLE
Mention (multi-document) YAML streams

### DIFF
--- a/draft-ietf-httpapi-yaml-mediatypes.md
+++ b/draft-ietf-httpapi-yaml-mediatypes.md
@@ -84,7 +84,8 @@ The source code and issues list for this draft can be found at
 
 YAML [YAML] is a data serialization format
 that is capable of conveying multiple independent
-documents in a single presentation stream.
+documents in a single presentation stream
+(e.g. a file or a network resource).
 It is widely used on the Internet,
 including in the API sector (e.g. see [OAS]),
 but the relevant media type and structured syntax suffix previously had not been registered by IANA.

--- a/draft-ietf-httpapi-yaml-mediatypes.md
+++ b/draft-ietf-httpapi-yaml-mediatypes.md
@@ -336,7 +336,7 @@ YAML documents.
 When receiving a multi-document stream,
 an application that only expects one-document
 streams, ought to signal an error
-instead of ingnoring the extra documents.
+instead of ignoring the extra documents.
 
 ## YAML and JSON {#int-yaml-and-json}
 

--- a/draft-ietf-httpapi-yaml-mediatypes.md
+++ b/draft-ietf-httpapi-yaml-mediatypes.md
@@ -83,7 +83,7 @@ The source code and issues list for this draft can be found at
 # Introduction
 
 YAML [YAML] is a data serialization format
-that is capable of conveying multiple independent
+that is capable of conveying one or multiple independent
 documents in a single presentation stream
 (e.g. a file or a network resource).
 It is widely used on the Internet,
@@ -132,7 +132,7 @@ or that starts with "/"
 is to be interpreted as a JSON Pointer {{JSON-POINTER}}
 and is evaluated on the YAML representation graph,
 walking through alias nodes;
-in particular, the emtpy fragment identifier
+in particular, the empty fragment identifier
 references the root node.
 This syntax can only reference the YAML nodes that are
 on a path that is made up of nodes interoperable with

--- a/draft-ietf-httpapi-yaml-mediatypes.md
+++ b/draft-ietf-httpapi-yaml-mediatypes.md
@@ -336,16 +336,17 @@ can specify it in YAML documents using the `%YAML` directive
 
 ## YAML streams {#int-yaml-streams}
 
-A YAML stream can contain zero or more
-YAML documents.
+A YAML stream can contain zero or more YAML documents.
 
 When receiving a multi-document stream,
-an application that only expects one-document
-streams, ought to signal an error
-instead of ignoring the extra documents.
+an application that only expects one-document streams,
+ought to signal an error instead of ignoring the extra documents.
 
-Current implementations consider different
-documents in a stream independent.
+Current implementations consider different documents in a stream independent,
+similarly to JSON Text Sequences (see {{?RFC7464}});
+elements such as anchors are not guaranteed to be referenceable
+across different documents.
+
 
 ## YAML and JSON {#int-yaml-and-json}
 

--- a/draft-ietf-httpapi-yaml-mediatypes.md
+++ b/draft-ietf-httpapi-yaml-mediatypes.md
@@ -397,15 +397,15 @@ issues with JSON:
    [0, 1]: a sequence
    ? {k: v}
    : a map
- non-json-value: 2020-01-01
  ...
  %YAML 1.1
  ---
  non-json-keys:
    2020-01-01: a timestamp
+ non-json-value: 2020-01-01
  ...
 ~~~
-{: title="Example of mapping keys not supported in JSON in a multi-document YAML stream" #example-unsupported-keys}
+{: title="Example of mapping keys and values not supported in JSON in a multi-document YAML stream" #example-unsupported-keys}
 
 ## Fragment identifiers {#int-fragment}
 

--- a/draft-ietf-httpapi-yaml-mediatypes.md
+++ b/draft-ietf-httpapi-yaml-mediatypes.md
@@ -485,6 +485,18 @@ to carefully test the implementation you are going to use.
 The same considerations apply when serializing a YAML representation graph
 in a format that does not support reference cycles (see {{int-yaml-and-json}}).
 
+
+## YAML streams
+
+Incremental parsing and processing of a YAML stream can produce partial results
+and later indicate failure to parse the remainder of the stream;
+to prevent partial processing, implementers might prefer validating all the documents in a stream beforehand.
+
+Repeated parsing and re-encoding of a YAML stream can result
+in the addition or removal of document delimiters (e.g. `---` or `...`)
+as well as the modification of anchor names and other serialization details:
+this can break signature validation.
+
 # IANA Considerations
 
 This specification defines the following new Internet media type {{MEDIATYPE}}.

--- a/draft-ietf-httpapi-yaml-mediatypes.md
+++ b/draft-ietf-httpapi-yaml-mediatypes.md
@@ -83,7 +83,7 @@ The source code and issues list for this draft can be found at
 # Introduction
 
 YAML [YAML] is a data serialization format
-that is capable of conveying one or multiple independent
+that is capable of conveying one or multiple
 documents in a single presentation stream
 (e.g. a file or a network resource).
 It is widely used on the Internet,
@@ -121,13 +121,13 @@ in this document are to be interpreted as in [YAML].
 
 ## Fragment identification {#application-yaml-fragment}
 
-Fragment identifiers only apply to YAML streams
-containing a single document.
+A fragment identifies a node in a stream.
 
 A fragment identifier starting with "*"
 is to be interpreted as a YAML alias node {{fragment-alias-node}}.
 
-A fragment identifier that is empty
+For single-document YAML streams,
+a fragment identifier that is empty
 or that starts with "/"
 is to be interpreted as a JSON Pointer {{JSON-POINTER}}
 and is evaluated on the YAML representation graph,
@@ -167,10 +167,11 @@ Users concerned with interoperability of fragment identifiers:
 - SHOULD NOT use alias nodes that match multiple nodes.
 
 In the example resource below, the URL `file.yaml#*foo`
-references the alias node `*foo` pointing to the node with value `scalar`;
+references the first alias node `*foo` pointing to the node with value `scalar`
+and not the one in the second document;
 whereas
-the URL `file.yaml#*bar` references the alias node `*bar` pointing to the node
-with value `[ some, sequence, items ]`.
+the URL `file.yaml#*document_2` references the root node
+of the second document `{ one: [a, sequence]}`.
 
 ~~~ example
  %YAML 1.2
@@ -180,8 +181,13 @@ with value `[ some, sequence, items ]`.
    - some
    - sequence
    - items
+ ...
+ %YAML 1.2
+ ---
+ &document_2
+ one: &foo [a, sequence]
 ~~~
-{: title="A YAML stream containing one YAML document." }
+{: title="A YAML stream containing two YAML documents." }
 
 # Media Type and Structured Syntax Suffix registrations
 
@@ -337,6 +343,9 @@ When receiving a multi-document stream,
 an application that only expects one-document
 streams, ought to signal an error
 instead of ignoring the extra documents.
+
+Current implementations consider different
+documents in a stream independent.
 
 ## YAML and JSON {#int-yaml-and-json}
 

--- a/draft-ietf-httpapi-yaml-mediatypes.md
+++ b/draft-ietf-httpapi-yaml-mediatypes.md
@@ -406,12 +406,10 @@ issues with JSON:
    [0, 1]: a sequence
    ? {k: v}
    : a map
- ...
- %YAML 1.1
  ---
  non-json-keys:
-   2020-01-01: a timestamp
- non-json-value: 2020-01-01
+   !date 2020-01-01: a timestamp
+ non-json-value: !date 2020-01-01
  ...
 ~~~
 {: title="Example of mapping keys and values not supported in JSON in a multi-document YAML stream" #example-unsupported-keys}


### PR DESCRIPTION
## This PR

- clarifies that YAML serializations are streams
- streams can be multi-document

cc: @perlpunk  